### PR TITLE
Remove the max height on the image block

### DIFF
--- a/gallery/src/gallery.html.erb
+++ b/gallery/src/gallery.html.erb
@@ -23,7 +23,6 @@
       }
       .image-block {
         flex: 0 0 33%;
-        max-height: 350px;
       }
       .image-caption {
         display: block;


### PR DESCRIPTION
Things look better without it

BEFORE:
![image](https://user-images.githubusercontent.com/315158/107167733-8dfc7000-69f4-11eb-9700-3cbbc721162e.png)

AFTER:
![image](https://user-images.githubusercontent.com/315158/107167767-a10f4000-69f4-11eb-80b9-b2615a351372.png)
